### PR TITLE
Fix incorrect reference of SwiftSH.xcframework

### DIFF
--- a/SwiftTermApp.xcodeproj/project.pbxproj
+++ b/SwiftTermApp.xcodeproj/project.pbxproj
@@ -84,8 +84,8 @@
 		4967BA03245A7AF300A9D2A6 /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
 		4967BA06245A85F800A9D2A6 /* SwCrypt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwCrypt.swift; sourceTree = "<group>"; };
 		4973B42B24650B440087D978 /* UIViewController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+SwiftUI.swift"; sourceTree = "<group>"; };
-		499AEF75254D0BE3004E5D23 /* SwiftSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftSH.xcframework; path = ../SwiftSH/SwiftSH.xcframework; sourceTree = "<group>"; };
-		499AEF7A254D0CE3004E5D23 /* SwiftSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftSH.xcframework; path = ../SwiftSH.xcframework; sourceTree = "<group>"; };
+		499AEF75254D0BE3004E5D23 /* SwiftSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftSH.xcframework; path = SwiftSH.binaries/SwiftSH.xcframework; sourceTree = "<group>"; };
+		499AEF7A254D0CE3004E5D23 /* SwiftSH.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SwiftSH.xcframework; path = SwiftSH.binaries/SwiftSH.xcframework; sourceTree = "<group>"; };
 		49A0A2BD2491C792002593F7 /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		49A0A2BF2491CDC4002593F7 /* InteractiveLogin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractiveLogin.swift; sourceTree = "<group>"; };
 		49A0A2C1249298BF002593F7 /* DigitalBrain.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = DigitalBrain.metal; sourceTree = "<group>"; };


### PR DESCRIPTION
I don't know if this will break others' environment but I had to change this for it to compile on my machine.