### PR TITLE
Actors async

### DIFF
--- a/SwiftTermApp.xcodeproj/project.pbxproj
+++ b/SwiftTermApp.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		49A4466126A3D76200A636DC /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A4466026A3D76200A636DC /* Commands.swift */; };
 		49A64C6126842A480069C7FA /* HostConnectionClosed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A64C6026842A480069C7FA /* HostConnectionClosed.swift */; };
 		49B49D9C27A9B7F00031A9AE /* SFTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B49D9B27A9B7F00031A9AE /* SFTP.swift */; };
+		49B49DB127AC70B40031A9AE /* SessionActor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B49DB027AC70B40031A9AE /* SessionActor.swift */; };
 		49B84C53268137C700B36066 /* HostAuthUnknown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B84C52268137C700B36066 /* HostAuthUnknown.swift */; };
 		49B84C5526813F9400B36066 /* HostAuthKeyMismatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B84C5426813F9400B36066 /* HostAuthKeyMismatch.swift */; };
 		49BA359626751B2700B63510 /* GenerateSecureEnclave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BA359526751B2700B63510 /* GenerateSecureEnclave.swift */; };
@@ -125,6 +126,7 @@
 		49A4466026A3D76200A636DC /* Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commands.swift; sourceTree = "<group>"; };
 		49A64C6026842A480069C7FA /* HostConnectionClosed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostConnectionClosed.swift; sourceTree = "<group>"; };
 		49B49D9B27A9B7F00031A9AE /* SFTP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFTP.swift; sourceTree = "<group>"; };
+		49B49DB027AC70B40031A9AE /* SessionActor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionActor.swift; sourceTree = "<group>"; };
 		49B84C512681215300B36066 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		49B84C52268137C700B36066 /* HostAuthUnknown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAuthUnknown.swift; sourceTree = "<group>"; };
 		49B84C5426813F9400B36066 /* HostAuthKeyMismatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostAuthKeyMismatch.swift; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				493F4F33276511CE00838AC7 /* Channel.swift */,
 				498DC727279A09FA003EC3CC /* LibsshKnownHost.swift */,
 				49B49D9B27A9B7F00031A9AE /* SFTP.swift */,
+				49B49DB027AC70B40031A9AE /* SessionActor.swift */,
 			);
 			path = Ssh;
 			sourceTree = "<group>";
@@ -543,6 +546,7 @@
 				49BA35ED267BE7AB00B63510 /* HostKeysList.swift in Sources */,
 				4967BA0224592D3600A9D2A6 /* SessionsView.swift in Sources */,
 				49BA35F1267C3F2600B63510 /* CreditsView.swift in Sources */,
+				49B49DB127AC70B40031A9AE /* SessionActor.swift in Sources */,
 				498DC728279A09FA003EC3CC /* LibsshKnownHost.swift in Sources */,
 				4973B42C24650B440087D978 /* UIViewController+SwiftUI.swift in Sources */,
 				49BA359C2676F15D00B63510 /* KeySummaryView.swift in Sources */,

--- a/SwiftTermApp/Ssh/Channel.swift
+++ b/SwiftTermApp/Ssh/Channel.swift
@@ -18,10 +18,10 @@ public class Channel: Equatable {
     var buffer, bufferError: UnsafeMutablePointer<Int8>
     let bufferSize = 32*1024
     var sendQueue = DispatchQueue (label: "channelSend", qos: .userInitiated)
-    var readCallback: ((Channel, Data?, Data?)->())
+    var readCallback: ((Channel, Data?, Data?)async->())
 
     
-    init (session: Session, channelHandle: OpaquePointer, readCallback: @escaping (Channel, Data?, Data?)->()) {
+    init (session: Session, channelHandle: OpaquePointer, readCallback: @escaping (Channel, Data?, Data?)async->()) {
         self.channelHandle = channelHandle
         self.sessionActor = session.sessionActor
         self.session = session
@@ -32,9 +32,11 @@ public class Channel: Equatable {
     }
     
     deinit {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
-        libssh2_channel_free(channelHandle)
+        let s = sessionActor!
+        let t = channelHandle
+        Task {
+            await s.free (channelHandle: t)
+        }
     }
 
     // Equatable.func == 
@@ -44,89 +46,52 @@ public class Channel: Equatable {
     
 
     public func setEnvironment (name: String, value: String) async {
-        let _ = await sessionActor.channelSetEnv (self, name: name, value: value)
+        let _ = await sessionActor.setEnv (channel: self, name: name, value: value)
     }
     
     // Returns 0 on success, or a LIBSSH2 error otherwise, always retries operations, so EAGAIN is never returned
     public func requestPseudoTerminal (name: String, cols: Int, rows: Int) async -> Int32 {
-        return await sessionActor.requestPseudoTerminal(self, name: name, cols: cols, rows: rows)
+        return await sessionActor.requestPseudoTerminal(channel: self, name: name, cols: cols, rows: rows)
     }
     
     public func setTerminalSize (cols: Int, rows: Int, pixelWidth: Int, pixelHeight: Int) async {
-        return await sessionActor.setTerminalSize(self, cols: cols, rows: rows, pixelWidth: pixelWidth, pixelHeight: pixelHeight)
+        return await sessionActor.setTerminalSize(channel: self, cols: cols, rows: rows, pixelWidth: pixelWidth, pixelHeight: pixelHeight)
     }
 
     // Returns 0 on success, or a LIBSSH2 error otherwise, always retries operations, so EAGAIN is never returned
     public func processStartup (request: String, message: String?) async -> Int32 {
-        return await sessionActor.processStartup(self, request: request, message: message)
+        return await sessionActor.processStartup(channel: self, request: request, message: message)
     }
     
     public var receivedEOF: Bool {
         get {
-            dispatchPrecondition(condition: .onQueue(sshQueue))
-
             return libssh2_channel_eof(channelHandle) == 1
         }
     }
     
     // Invoked when there is some data received on the session, and we try to fetch it for the channel
     // if it is available, we dispatch it.
-    func ping () {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        // standard channel
-        let streamId: Int32 = 0
-        var ret, retError: Int
-        
-        ret = libssh2_channel_read_ex (channelHandle, streamId, buffer, bufferSize)
-        retError = libssh2_channel_read_ex (channelHandle, SSH_EXTENDED_DATA_STDERR, bufferError, bufferSize)
-
-        let data = ret >= 0 ? Data (bytesNoCopy: buffer, count: ret, deallocator: .none) : nil
-        let error = retError >= 0 ? Data (bytesNoCopy: bufferError, count: retError, deallocator: .none) : nil
+    func ping () async {
+        let pair = await sessionActor.ping(channel: self)
         
         if receivedEOF {
             session.unregister(channel: self)
         }
-        if ret >= 0 || retError >= 0 {
-            readCallback (self, data, error)
-        } else {
-            // Nothing read
+        if let channelData = pair {
+            await readCallback (self, channelData.0, channelData.1)
         }
     }
     
-    func close () {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
-        while libssh2_channel_close(channelHandle) == LIBSSH2_ERROR_EAGAIN {
-            // Wait
-        }
+    func close () async {
+        await sessionActor.close (channel: self)
     }
     
     /// Sends the provided data to the channel, and invokes the callback with the status code when doneaaaa
-    func send (_ data: Data, callback: @escaping (Int)->()) {
-        if data.count == 0 {
-            return
-        }
-        sshQueue.async {
-            data.withUnsafeBytes { (unsafeBytes) in
-                let bytes = unsafeBytes.bindMemory(to: CChar.self).baseAddress!
-                
-                let ret = libssh2_channel_write_ex(self.channelHandle, 0, bytes, data.count)
-                if ret < 0 {
-                    print ("DEBUG libssh2_channel_write_ex result: \(libSsh2ErrorToString(error:Int32(ret)))")
-                }
-                
-                callback (ret)
-            }
-        }
+    func send (_ data: Data, callback: @escaping (Int)->()) async {
+        await sessionActor.send (channel: self, data: data, callback: callback)
     }
     
-    func exec (_ command: String) -> Int32 {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
-        var ret: Int32 = 0
-        repeat {
-            ret = libssh2_channel_process_startup (channelHandle, "exec", 4, command, UInt32(command.utf8.count))
-        } while ret == LIBSSH2_ERROR_EAGAIN
-        return ret
+    func exec (_ command: String) async -> Int32 {
+        return await sessionActor.exec (channel: self, command: command)
     }
 }

--- a/SwiftTermApp/Ssh/LibsshKnownHost.swift
+++ b/SwiftTermApp/Ssh/LibsshKnownHost.swift
@@ -57,7 +57,7 @@ class LibsshKnownHost {
     
     // returns nil on success, otherwise an error description
     func readFile (filename: String) async -> String? {
-        return await sessionActor.readFile (khHandle, filename: filename)
+        return await sessionActor.readFile (knownHost: self, filename: filename)
     }
     
     // returns nil on success, otherwise an error description

--- a/SwiftTermApp/Ssh/LibsshKnownHost.swift
+++ b/SwiftTermApp/Ssh/LibsshKnownHost.swift
@@ -48,7 +48,7 @@ class LibsshKnownHost {
     }
     
     var khHandle: OpaquePointer
-    weak var sessionActor: SessionActor?
+    weak var sessionActor: SessionActor!
     
     init (sessionActor: SessionActor, knownHost: OpaquePointer){
         self.sessionActor = sessionActor
@@ -57,7 +57,7 @@ class LibsshKnownHost {
     
     // returns nil on success, otherwise an error description
     func readFile (filename: String) async -> String? {
-        return await sessionActor!.readFile (khHandle, filename: filename)
+        return await sessionActor.readFile (khHandle, filename: filename)
     }
     
     // returns nil on success, otherwise an error description

--- a/SwiftTermApp/Ssh/SFTP.swift
+++ b/SwiftTermApp/Ssh/SFTP.swift
@@ -20,11 +20,15 @@ public class SFTP {
     }
     
     deinit {
-        Task { await session.sessionActor.sftpShutdown (sftpHandle) }
+        let h = sftpHandle
+        let k = session.sessionActor
+        Task {
+            await k.sftpShutdown (h)
+        }
     }
 
-    func stat (path: String) -> LIBSSH2_SFTP_ATTRIBUTES? {
-        session.sessionActor.sftpStat (self, path: path)
+    func stat (path: String) async -> LIBSSH2_SFTP_ATTRIBUTES? {
+        await session.sessionActor.sftpStat (self, path: path)
     }
 
     func llOpen (path: String, flags: UInt, file: Bool) async -> OpaquePointer? {

--- a/SwiftTermApp/Ssh/SFTP.swift
+++ b/SwiftTermApp/Ssh/SFTP.swift
@@ -15,69 +15,28 @@ public class SFTP {
     weak var session: Session!
     
     init (session: Session, sftpHandle: OpaquePointer) {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
         self.sftpHandle = sftpHandle
         self.session = session
     }
     
     deinit {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
-        libssh2_sftp_shutdown (sftpHandle)
+        Task { await session.sessionActor.sftpShutdown (sftpHandle) }
     }
 
     func stat (path: String) -> LIBSSH2_SFTP_ATTRIBUTES? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-
-        var ret: CInt = 0
-        var attr: LIBSSH2_SFTP_ATTRIBUTES = LIBSSH2_SFTP_ATTRIBUTES()
-        let pc = UInt32 (path.utf8.count)
-        
-        repeat {
-            ret = libssh2_sftp_stat_ex(sftpHandle, path, pc, LIBSSH2_SFTP_STAT, &attr)
-        } while ret == LIBSSH2_ERROR_EAGAIN
-        return ret == 0 ? attr : nil
+        session.sessionActor.sftpStat (self, path: path)
     }
 
-    func llOpen (path: String, flags: UInt, file: Bool) -> OpaquePointer? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        let pc = UInt32 (path.utf8.count)
-        var handle: OpaquePointer!
-        repeat {
-            handle = libssh2_sftp_open_ex(sftpHandle, path, pc, flags, 0, file ? LIBSSH2_SFTP_OPENFILE : LIBSSH2_SFTP_OPENDIR)
-        } while handle == nil && libssh2_session_last_errno(session!.sessionHandle) == LIBSSH2_ERROR_EAGAIN
-        return handle
+    func llOpen (path: String, flags: UInt, file: Bool) async -> OpaquePointer? {
+        await session.sessionActor.sftpLlOpen (self, path: path, flags: flags, file: file)
     }
     
-    func readFile (path: String, limit: Int) -> [Int8]? {
-        guard let f = llOpen (path: path, flags: UInt (LIBSSH2_FXF_READ), file: true) else {
-            return nil
-        }
-        var buffer: [Int8] = []
-        let size = 8192
-        var llbuffer = Array<Int8>.init(repeating: 0, count: size)
-        var ret: Int = 0
-        var left = limit
-        repeat {
-            ret = libssh2_sftp_read(f, &llbuffer, min (size, left))
-            if ret > 0 {
-                left -= ret
-                buffer.append(contentsOf: llbuffer [0..<ret])
-            }
-            if ret == 0 {
-                break
-            }
-        } while ret == LIBSSH2_ERROR_EAGAIN || left > 0
-        ret = 0
-        repeat {
-            ret = Int (libssh2_sftp_close_handle(f))
-        } while ret == LIBSSH2_ERROR_EAGAIN
-        return buffer
+    func readFile (path: String, limit: Int) async -> [Int8]? {
+        await session.sessionActor.sftpReadFile (self, path: path, limit: limit)
     }
     
-    func readFileAsString (path: String, limit: Int) -> String? {
-        if let bytes = readFile (path: path, limit: limit) {
+    func readFileAsString (path: String, limit: Int) async -> String? {
+        if let bytes = await readFile (path: path, limit: limit) {
             let d = Data (bytes: bytes, count: bytes.count)
             return String (bytes: d, encoding: .utf8)
         }

--- a/SwiftTermApp/Ssh/Session.swift
+++ b/SwiftTermApp/Ssh/Session.swift
@@ -47,7 +47,7 @@ protocol SessionDelegate: AnyObject {
     /// connection has been established.
     /// - Parameter session: identifies the session that this callback is for
     /// - Returns: nil on success, or a human-readable description as a string on error
-    func authenticate (session: Session) -> String?
+    func authenticate (session: Session) async -> String?
     
     /// Called if we failed to login on the network queue
     /// - Parameter session: identifies the session that this callback is for
@@ -55,7 +55,7 @@ protocol SessionDelegate: AnyObject {
     
     /// Called when we are authenticated on the network queue, and channels can be opened
     /// - Parameter session: identifies the session that this callback is for
-    func loggedIn (session: Session)
+    func loggedIn (session: Session) async
     
     /// Called on the sshQueue, this message is invoked in response to receiving an `SSH_MSG_DEBUG` message
     /// described in https://datatracker.ietf.org/doc/html/rfc4253
@@ -87,16 +87,12 @@ class Session: CustomDebugStringConvertible {
     
     // Handle to the libssh2 Session
     var sessionHandle: OpaquePointer!
+    var sessionActor: SessionActor
     
     var channelsLock = NSLock ()
     
     // Where we post interesting events about this session
     weak var delegate: SessionDelegate!
-    
-    typealias disconnectType = @convention(c) (UnsafeRawPointer, CInt,
-                                               UnsafePointer<CChar>, CInt,
-                                               UnsafePointer<CChar>, CInt, UnsafeRawPointer) -> Void
-    
     
     // Turns the libssh2 abstract pointer (which is a pointer to the value passed) into a strong type
     static func getSession (from abstract: UnsafeRawPointer) -> Session {
@@ -104,38 +100,15 @@ class Session: CustomDebugStringConvertible {
         return Unmanaged<Session>.fromOpaque(ptr.pointee).takeUnretainedValue()
     }
 
-    public init (delegate: SessionDelegate) {
+    public init (delegate: SessionDelegate, send: @escaping socketCbType, recv: @escaping socketCbType, debug: @escaping debugCbType) {
         self.delegate = delegate
+        
         channelsLock = NSLock ()
-
-        sshQueue.sync {
-            libssh2_init (0)
-            let opaqueHandle = UnsafeMutableRawPointer(mutating: Unmanaged.passUnretained(self).toOpaque())
-            sessionHandle = libssh2_session_init_ex(nil, nil, nil, opaqueHandle)
-            let flags: Int32 = 0
-            libssh2_trace(sessionHandle, flags)
-            libssh2_trace_sethandler(sessionHandle, nil, { session, context, data, length in
-                var str: String
-                if let ptr = data {
-                    str = String (cString: ptr)
-                } else {
-                    str = "<null>"
-                }
-                print ("Trace callback: \(str)")
-            })
-            
-            let callback: disconnectType = { sessionPtr, reason, message, messageLen, language, languageLen, abstract in
-                let session = Session.getSession(from: abstract)
-                
-                print ("On session: \(session)")
-                print ("Disconnected")
-                session.disconnect(reason: SSH_DISCONNECT_CONNECTION_LOST, description: "")
-            }
-            libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DISCONNECT, unsafeBitCast(callback, to: UnsafeMutableRawPointer.self))
-            // TODO: wish of mine: should set all the callbacjs, and handle every scenario
-            setupCallbacks ()
-        }
-    
+        
+        // Init this first, we will wipe it out soon enough
+        sessionActor = SessionActor (fakeSetup: true)
+        let opaqueHandle = UnsafeMutableRawPointer(mutating: Unmanaged.passUnretained(self).toOpaque())
+        sessionActor = SessionActor (send: send, recv: recv, debug: debug, opaque: opaqueHandle)
     }
     
     var debugDescription: String {
@@ -157,42 +130,18 @@ class Session: CustomDebugStringConvertible {
     ///   * LIBSSH2_HOSTKEY_TYPE_ED25519
     /// - Returns: tuple with the key as an array of bytes and the type.
     /// Returns the key and type for the host.  The key is one of
-    public func hostKey () -> (key: [Int8], type: Int32)? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        
-        var len: Int = 0
-        var type: Int32 = 0
-
-        let ptr = libssh2_session_hostkey(sessionHandle, &len, &type)
-        if ptr == nil {
-            return nil
-        }
-        let data = UnsafeBufferPointer (start: ptr, count: len)
-        return (data.map { $0 }, type)
+    public func hostKey () async -> (key: [Int8], type: Int32)? {
+        return await sessionActor.hostKey ()
     }
 
     /// Performs the SSH session handshake
-    public func handshake () {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        while libssh2_session_handshake(sessionHandle, 0) == LIBSSH2_ERROR_EAGAIN {
-            // Repeat while we get EAGAIN
-        }
+    public func handshake () async -> Int32 {
+        return await sessionActor.handshake ()
     }
     
     /// Returns an array of authentication methods available for the specified user
-    public func userAuthenticationList (username: String) -> [String] {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        var result: UnsafeMutablePointer<CChar>!
-        
-        timeout = Date (timeIntervalSinceNow: 2)
-        result = libssh2_userauth_list (sessionHandle, username, UInt32(username.utf8.count))
-        timeout = nil
-        if result == nil {
-            let code = libssh2_session_last_errno(sessionHandle)
-            print ("Got error: ssh2error: \(code)")
-            return []
-        }
-        return String (validatingUTF8: result)?.components(separatedBy: ",") ?? []
+    public func userAuthenticationList (username: String) async -> [String] {
+        return await sessionActor.userAuthenticationList (username: username)
     }
     
     /// Returns the hostkey SHA256 hash from the session as an array of bytes
@@ -219,14 +168,16 @@ class Session: CustomDebugStringConvertible {
     var timeout: Date?
     public private(set) var banner: String = ""
     
-    func setupSshConnection ()
+    func setupSshConnection () async
     {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        handshake()
-        banner = String (cString: libssh2_session_banner_get(sessionHandle))
-        let failureReason = delegate.authenticate(session: self)
-        if authenticated {
-            delegate.loggedIn(session: self)
+        if await handshake() != 0 {
+            // There was an error
+            // TODO: handle this one
+        }
+        banner = await String (cString: libssh2_session_banner_get(sessionActor.sessionHandle))
+        let failureReason = await delegate.authenticate(session: self)
+        if await authenticated {
+            await delegate.loggedIn(session: self)
         } else {
             delegate.loginFailed (session: self, details: failureReason ?? "Internal error: authentication claims it worked, but libssh2 state indicates it is not authenticated")
         }
@@ -234,33 +185,8 @@ class Session: CustomDebugStringConvertible {
     
     /// Determines if the session has been authenticated
     public var authenticated: Bool {
-        get {
-            dispatchPrecondition(condition: .onQueue(sshQueue))
-            return libssh2_userauth_authenticated(sessionHandle) == 1
-        }
-    }
-    
-    // Returns nil on success, or a description of the code on error
-    func authErrorToString (code: CInt) -> String? {
-        switch code {
-        case 0:
-            // We are fine, return
-            return nil
-        case LIBSSH2_ERROR_ALLOC:
-            // WE are doomed, return
-            return "Memory allocation failure"
-        case LIBSSH2_ERROR_SOCKET_SEND:
-            // We are doomed return, upper Network layer will notify of this problem
-            return "Unable to send data to remote host"
-        case LIBSSH2_ERROR_PASSWORD_EXPIRED:
-            // the password expired, but we failed to change it (to fix, we will need to provide a callback)
-            return "Password expired"
-        case LIBSSH2_ERROR_AUTHENTICATION_FAILED:
-            // Failed, try the next password
-            return "Password authentication failed"
-        default:
-            // Unknown error, return
-            return "Unknown error during authentication"
+        get async {
+            return await sessionActor.authenticated
         }
     }
     
@@ -291,37 +217,9 @@ class Session: CustomDebugStringConvertible {
     /// Performs an interactive user authentication for the specified username
     /// - Parameter prompt: method to invoke to present the prompt to the user
     /// - Returns: nil on success, or a user-visible description on error
-    public func userAuthKeyboardInteractive (username: String, prompt: @escaping (String)->String) -> String? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        
-        var ret: CInt
-        self.promptFunc = prompt
-        
-        let usernameCount = UInt32 (username.utf8.count)
-        repeat {
-            ret = libssh2_userauth_keyboard_interactive_ex(sessionHandle, username, usernameCount) { name, nameLen, instruction, instructionLen, numPrompts, prompts, responses, abstract in
-                for i in 0..<Int(numPrompts) {
-                    guard let prompt = prompts?[i], let text = prompt.text else {
-                        continue
-                    }
-
-                    let data = Data (bytes: UnsafeRawPointer (text), count: Int(prompt.length))
-
-                    guard let challenge = String (data: data, encoding: .utf8) else {
-                        continue
-                    }
-
-                    let session = Session.getSession (from: abstract!)
-                    let password = session.promptFunc! (challenge)
-                    let response = password.withCString {
-                         LIBSSH2_USERAUTH_KBDINT_RESPONSE(text: strdup($0), length: UInt32(strlen(password)))
-                    }
-                    responses?[i] = response
-                }
-            }
-        } while ret == LIBSSH2_ERROR_EAGAIN
-        self.promptFunc = nil
-        return authErrorToString(code: ret)
+    public func userAuthKeyboardInteractive (username: String, prompt: @escaping (String)->String) async -> String? {
+        promptFunc = prompt
+        return await sessionActor.userAuthKeyboardInteractive(username: username)
     }
     
     /// Authenticates using the provided public/private key pairs
@@ -332,7 +230,6 @@ class Session: CustomDebugStringConvertible {
     ///  - privateKey: contents of the private key
     /// - Returns: nil on success, or a user-visible description on error
     public func userAuthPublicKeyFromMemory (username: String, passPhrase: String, publicKey: String, privateKey: String) -> String? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
         
         var ret: CInt = 0
         
@@ -391,18 +288,11 @@ class Session: CustomDebugStringConvertible {
     ///  - packetSize: Maximum number of bytes remote host is allowed to send in a single SSH_MSG_CHANNEL_DATA or SSG_MSG_CHANNEL_EXTENDED_DATA packet, defaults to 32k
     ///  - readCallback: method that is invoked when new data is available on the channel, it receives the channel source as a parameter, and two Data? parameters,
     ///   one for standard output, and one for standard error.
-    public func openChannel (type: String, windowSize: CUnsignedInt = 2*1024*1024, packetSize: CUnsignedInt = 32768, readCallback: @escaping (Channel, Data?, Data?)->())  -> Channel? {
-        var ret: OpaquePointer?
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        let typeCount = UInt32(type.utf8.count)
-        repeat {
-            ret = libssh2_channel_open_ex(sessionHandle, type, typeCount, windowSize, packetSize, nil, 0)
-        } while ret == nil && libssh2_session_last_errno (sessionHandle) == LIBSSH2_ERROR_EAGAIN
-        guard let channelHandle = ret else {
-            return nil
-        }
-        let channel = Channel (session: self, channelHandle: channelHandle, readCallback: readCallback)
-        return channel
+    public func openChannel (type: String,
+                             windowSize: CUnsignedInt = 2*1024*1024,
+                             packetSize: CUnsignedInt = 32768,
+                             readCallback: @escaping (Channel, Data?, Data?)->()) async -> Channel? {
+        return await sessionActor.openChannel(type: type, windowSize: windowSize, packetSize: packetSize, readCallback: readCallback)
     }
     
     /// Opens a new session channel with the defaults, and with the specified LANG environment variable set
@@ -410,9 +300,9 @@ class Session: CustomDebugStringConvertible {
     ///  - lang: The desired value for the LANG environment variable to be set on the remote end
     ///  - readCallback: method that is invoked when new data is available on the channel, it receives the channel source as a parameter, and two Data? parameters,
     ///   one for standard output, and one for standard error.
-    public func openSessionChannel (lang: String, readCallback: @escaping (Channel, Data?, Data?)->())  -> Channel? {
-        if let channel = openChannel(type: "session", readCallback: readCallback) {
-            channel.setEnvironment(name: "LANG", value: lang)
+    public func openSessionChannel (lang: String, readCallback: @escaping (Channel, Data?, Data?)->()) async -> Channel? {
+        if let channel = await openChannel(type: "session", readCallback: readCallback) {
+            await channel.setEnvironment(name: "LANG", value: lang)
             return channel
         }
         return nil
@@ -424,8 +314,8 @@ class Session: CustomDebugStringConvertible {
     ///  - lang: The desired value for the LANG environment variable to be set on the remote end
     ///  - readCallback: method that is invoked when new data is available on the channel, it receives the channel source as a parameter, and two Data? parameters,
     ///   one for standard output, and one for standard error.
-    public func run (command: String, lang: String, readCallback: @escaping (Channel, Data?, Data?)->())  -> Channel? {
-        if let channel = openSessionChannel(lang: lang, readCallback: readCallback) {
+    public func run (command: String, lang: String, readCallback: @escaping (Channel, Data?, Data?)->()) async -> Channel? {
+        if let channel = await openSessionChannel(lang: lang, readCallback: readCallback) {
             let status = channel.exec (command)
             if status == 0 {
                 activate(channel: channel)
@@ -441,11 +331,11 @@ class Session: CustomDebugStringConvertible {
     ///  - command: the command to execute on the remote server
     ///  - lang: The desired value for the LANG environment variable to be set on the remote end
     ///  - resultCallback: method that is invoked when the command completes containing the stdout and stderr results as Data parameters
-    public func run (command: String, lang: String, resultCallback: @escaping (Data, Data)->()) {
+    public func run (command: String, lang: String, resultCallback: @escaping (Data, Data)->()) async {
         var stdout = Data()
         var stderr = Data()
         
-        run (command: command, lang: lang) { channel, out, err in
+        await run (command: command, lang: lang) { channel, out, err in
             //print ("Run callback for \(command) out=\(out?.count) err=\(err?.count) eof=\(channel.receivedEOF)")
             if let gotOut = out {
                 stdout.append(gotOut)
@@ -455,7 +345,9 @@ class Session: CustomDebugStringConvertible {
             }
             if channel.receivedEOF {
                 DispatchQueue.main.async {
-                    resultCallback (stdout, stderr)
+                    abort ()
+                    // TODO: next line
+                    // resultCallback (stdout, stderr)
                 }
                 return
             }
@@ -467,11 +359,14 @@ class Session: CustomDebugStringConvertible {
     ///  - command: the command to execute on the remote server
     ///  - lang: The desired value for the LANG environment variable to be set on the remote end
     ///  - resultCallback: method that is invoked when the command completes containing the stdout and stderr results as string parameters
-    public func runSimple (command: String, lang: String, resultCallback: @escaping (String?, String?)->()) {
+    ///
+    ///  TODO: if this is async, why provide a resultCallback, and instead just return the values when we are done?
+    public func runSimple (command: String, lang: String, resultCallback: @escaping (String?, String?)->()) async {
         var stdout = Data()
         var stderr = Data()
         
-        run (command: command, lang: lang) { channel, out, err in
+        
+        await run (command: command, lang: lang) { channel, out, err in
             //print ("Run callback for \(command) out=\(out?.count) err=\(err?.count) eof=\(channel.receivedEOF)")
             if let gotOut = out {
                 stdout.append(gotOut)
@@ -531,12 +426,8 @@ class Session: CustomDebugStringConvertible {
     }
     
     /// Creates an instance of the libssh2-level list of known hosts.
-    public func makeKnownHost () -> LibsshKnownHost? {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        guard let kh = libssh2_knownhost_init (sessionHandle) else {
-            return nil
-        }
-        return LibsshKnownHost (knownHost: kh)
+    public func makeKnownHost () async -> LibsshKnownHost? {
+        return await sessionActor.makeKnownHost()
     }
     
     public enum FingerprintHashType {
@@ -605,8 +496,24 @@ class SocketSession: Session {
         self.host = host
         self.port = port
         
+        let send: socketCbType = { socket, buffer, length, flags, abstract in
+            SocketSession.send_callback(socket: socket, buffer: buffer, length: length, flags: flags, abstract: abstract)
+        }
+        
+        let recv: socketCbType = { socket, buffer, length, flags, abstract in
+            return SocketSession.recv_callback(socket: socket, buffer: buffer, length: length, flags: flags, abstract: abstract)
+        }
+        let debug: debugCbType = { session, alwaysDisplay, messagePtr, messageLen, languagePtr, languageLen, abstract in
+            let msg = Data (bytes: messagePtr, count: Int (messageLen))
+            let lang = Data (bytes: languagePtr, count: Int (languageLen))
+            
+            let session = SocketSession.getSocketSession(from: abstract)
+            session.delegate.debug(session: session, alwaysDisplay: alwaysDisplay != 0, message: msg, language: lang)
+        }
+
         connection = NWConnection(host: NWEndpoint.Host (host), port: NWEndpoint.Port (integerLiteral: port), using: .tcp)
-        super.init (delegate: delegate)
+        super.init(delegate: delegate, send: send, recv: recv, debug: debug)
+        
         connection.stateUpdateHandler = connectionStateHandler
         connection.start (queue: SocketSession.networkQueue)
     }
@@ -661,9 +568,11 @@ class SocketSession: Session {
             }
             self.bufferLock.unlock()
             
+            // TODO: maybe we do not need PingChannels, we can merge with pingtasks?
             sshQueue.async {
                 self.pingChannels ()
             }
+            Task { await self.sessionActor.pingTasks() }
             
             if restart {
                 self.startIO()
@@ -705,8 +614,8 @@ class SocketSession: Session {
         case .ready:
             log ("ready")
             startIO()
-            sshQueue.sync {
-                self.setupSshConnection ()
+            Task {
+                await setupSshConnection ()
             }
         case .failed(_):
             log ("failed")
@@ -804,32 +713,7 @@ class SocketSession: Session {
         let ret = successOrError(wasError, n: consumedBytes)
         return ret
     }
-    
-    typealias socketCbType = @convention(c) (libssh2_socket_t, UnsafeRawPointer, size_t, CInt, UnsafeRawPointer) -> ssize_t
-    typealias debugCbType  = @convention(c) (libssh2_socket_t, CInt, UnsafeRawPointer, CInt, UnsafeRawPointer, CInt, UnsafeRawPointer) -> ()
-    
-    public override func setupCallbacks () {
-        dispatchPrecondition(condition: .onQueue(sshQueue))
-        let send: socketCbType = { socket, buffer, length, flags, abstract in
-            SocketSession.send_callback(socket: socket, buffer: buffer, length: length, flags: flags, abstract: abstract)
-        }
         
-        let recv: socketCbType = { socket, buffer, length, flags, abstract in
-            return SocketSession.recv_callback(socket: socket, buffer: buffer, length: length, flags: flags, abstract: abstract)
-        }
-        let debug: debugCbType = { session, alwaysDisplay, messagePtr, messageLen, languagePtr, languageLen, abstract in
-            let msg = Data (bytes: messagePtr, count: Int (messageLen))
-            let lang = Data (bytes: languagePtr, count: Int (languageLen))
-            
-            let session = SocketSession.getSocketSession(from: abstract)
-            session.delegate.debug(session: session, alwaysDisplay: alwaysDisplay != 0, message: msg, language: lang)
-        }
-        libssh2_session_set_blocking (sessionHandle, 0)
-        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_SEND, unsafeBitCast(send, to: UnsafeMutableRawPointer.self))
-        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_RECV, unsafeBitCast(recv, to: UnsafeMutableRawPointer.self))
-        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DEBUG, unsafeBitCast(debug, to: UnsafeMutableRawPointer.self))
-    }
-    
     public override func disconnect (reason: Int32 = SSH_DISCONNECT_BY_APPLICATION, description: String) {
         super.disconnect(reason: reason, description: description)
         connection.forceCancel()
@@ -837,12 +721,9 @@ class SocketSession: Session {
 }
 
 class ProxySession: Session {
-    public override init (delegate: SessionDelegate)
+    public init (delegate: SessionDelegate)
     {
-        super.init (delegate: delegate)
-    }
-    
-    public override func setupCallbacks () {
+        abort ()
     }
 }
 

--- a/SwiftTermApp/Ssh/SessionActor.swift
+++ b/SwiftTermApp/Ssh/SessionActor.swift
@@ -22,14 +22,26 @@ typealias disconnectCbType = @convention(c) (UnsafeRawPointer, CInt,
                                            UnsafePointer<CChar>, CInt,
                                            UnsafePointer<CChar>, CInt, UnsafeRawPointer) -> Void
 
-typealias queuedOp = ()->Bool
-
+///
+/// Surfaces the libssh2 `Session` APIs and puts them behind an actor, ensuring that all operations on it
+/// are serialized.   This API surface is not only for the session, but also for any types that are thread-bound
+/// to the session, like channels created from the session, or the SFTP API.
 actor SessionActor {
+    typealias queuedOp = ()->Bool
+    
     // Handle to the libssh2 Session
     var sessionHandle: OpaquePointer!
 
+    // Purely helps to initialize the Session object
     init (fakeSetup: Bool) { }
-    init (send: @escaping socketCbType, recv: @escaping socketCbType, debug: @escaping debugCbType, opaque: UnsafeMutableRawPointer) {
+    
+    /// Initializes the session actor with methods to send, receive and notify about any debug information
+    /// - Parameters:
+    ///  - send: the method that will be invoked by libssh2 to send data over the connection
+    ///  - recv: the method that is invoked by libssh2 to receive data from the connection
+    ///  - debug: method to invoke when we receive a debug message from the server
+    ///  - opaque: the C-level context/closure.   This should point to the Session, and is allocated by the session.
+    init (send: @escaping socketCbType, recv: @escaping socketCbType, disconnect: @escaping disconnectCbType, debug: @escaping debugCbType, opaque: UnsafeMutableRawPointer) {
         libssh2_init (0)
         sessionHandle = libssh2_session_init_ex(nil, nil, nil, opaque)
         let flags: Int32 = 0
@@ -44,27 +56,76 @@ actor SessionActor {
             print ("Trace callback: \(str)")
         })
         
-        // TODO
-//        let callback: disconnectType = { sessionPtr, reason, message, messageLen, language, languageLen, abstract in
-//            let session = Session.getSession(from: abstract)
-//
-//            print ("On session: \(session)")
-//            print ("Disconnected")
-//            session.disconnect(reason: SSH_DISCONNECT_CONNECTION_LOST, description: "")
-//        }
-        //libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DISCONNECT, unsafeBitCast(callback, to: UnsafeMutableRawPointer.self))
+        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DISCONNECT, unsafeBitCast(disconnect, to: UnsafeMutableRawPointer.self))
         
         libssh2_session_set_blocking (sessionHandle, 0)
         libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_SEND, unsafeBitCast(send, to: UnsafeMutableRawPointer.self))
         libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_RECV, unsafeBitCast(recv, to: UnsafeMutableRawPointer.self))
         libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DEBUG, unsafeBitCast(debug, to: UnsafeMutableRawPointer.self))
     }
+    
+    var suspendedTasks = 0
+    func track (task: @escaping queuedOp) {
+        if task () {
+            suspendedTasks += 1
+            tasks.append (task)
+        }
+    }
+    
+    ///
+    /// Calls into a libssh2 function that uses the convention that where a `LIBSSH2_ERROR_EAGAIN`
+    /// return value indicates that the operation should be retried, but does so by waiting for new
+    /// data to be made available on the channel.
+    ///
+    /// - Parameter callback: a method that is expecred to return an Int32, and one of the
+    /// possible values is `LIBSSH2_ERROR_EAGAIN` which will trigger a new attempt to execute
+    func callSsh (_ callback: @escaping ()->Int32) async -> Int32 {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = callback()
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            track (task: op)
+        }
+    }
+
+    ///
+    /// Calls into a libssh2 function that returns a pointer value as a return, and that sets the
+    /// libssh2 errno to `LIBSSH2_ERROR_EAGAIN` to indicate that there is not enough data
+    /// availble and the operation should be retried.   If this is the case, then the operation is
+    /// queued for exectuion until new data to be made available on the channel.
+    ///
+    /// - Parameter callback: a method that is expecred to return an Int32, and one of the
+    /// possible values is `LIBSSH2_ERROR_EAGAIN` which will trigger a new attempt to execute
+    /// - Returns: an optional pointer value.
+    func callSshPtr<T> (_ callback: @escaping ()->T?) async -> T? {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = callback()
+                if ret == nil {
+                    let code = libssh2_session_last_errno(self.sessionHandle)
+                    if code == LIBSSH2_ERROR_EAGAIN {
+                        return true
+                    }
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            track (task: op)
+        }
+    }
 
     // These tasks return true if they should be kept on the list
     var tasks: [()->Bool] = []
     
+    /// To be invoked when new data has been read from the network for the channel,
+    /// this retries all pending tasks that were waiting for data to be made available.
     public func pingTasks () {
-        var copy = tasks
+        let copy = tasks
         tasks = []
         
         for task in copy {
@@ -87,46 +148,21 @@ actor SessionActor {
     }
 
     public func handshake () async -> Int32 {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                let ret = libssh2_session_handshake(self.sessionHandle, 0)
-                if ret == LIBSSH2_ERROR_EAGAIN {
-                    return true
-                }
-                c.resume(returning: ret)
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+        return await callSsh {
+            libssh2_session_handshake(self.sessionHandle, 0)
         }
     }
 
     public var timeout: Date?
     
     public func userAuthenticationList (username: String) async -> [String] {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                var result: UnsafeMutablePointer<CChar>!
-                
-                self.timeout = Date (timeIntervalSinceNow: 2)
-                result = libssh2_userauth_list (self.sessionHandle, username, UInt32(username.utf8.count))
-                self.timeout = nil
-                if result == nil {
-                    let code = libssh2_session_last_errno(self.sessionHandle)
-                    if code == LIBSSH2_ERROR_EAGAIN {
-                        return true
-                    }
-                    c.resume(returning: [])
-                } else {
-                    c.resume (returning: String (validatingUTF8: result)?.components(separatedBy: ",") ?? [])
-                }
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+        let ptr = await callSshPtr {
+            return libssh2_userauth_list (self.sessionHandle, username, UInt32(username.utf8.count))
         }
+        guard let ptr = ptr else {
+            return []
+        }
+        return String (validatingUTF8: ptr)?.components(separatedBy: ",") ?? []
     }
         
     public var authenticated: Bool {
@@ -136,40 +172,82 @@ actor SessionActor {
     }
     
     public func userAuthKeyboardInteractive (username: String) async -> String? {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                let usernameCount = UInt32 (username.utf8.count)
-                let ret = libssh2_userauth_keyboard_interactive_ex(self.sessionHandle, username, usernameCount) { name, nameLen, instruction, instructionLen, numPrompts, prompts, responses, abstract in
-                    let session = Session.getSession(from: abstract!)
-
-                    for i in 0..<Int(numPrompts) {
-                        guard let promptI = prompts?[i], let text = promptI.text else {
-                            continue
-                        }
-                        
-                        let data = Data (bytes: UnsafeRawPointer (text), count: Int(promptI.length))
-                        
-                        guard let challenge = String (data: data, encoding: .utf8) else {
-                            continue
-                        }
-                        
-                        let password = session.promptFunc! (challenge)
-                        let response = password.withCString {
-                            LIBSSH2_USERAUTH_KBDINT_RESPONSE(text: strdup($0), length: UInt32(strlen(password)))
-                        }
-                        responses?[i] = response
+        return await authErrorToString(code: callSsh {
+            let usernameCount = UInt32 (username.utf8.count)
+            return libssh2_userauth_keyboard_interactive_ex(self.sessionHandle, username, usernameCount) { name, nameLen, instruction, instructionLen, numPrompts, prompts, responses, abstract in
+                let session = Session.getSession(from: abstract!)
+                
+                for i in 0..<Int(numPrompts) {
+                    guard let promptI = prompts?[i], let text = promptI.text else {
+                        continue
                     }
+                    
+                    let data = Data (bytes: UnsafeRawPointer (text), count: Int(promptI.length))
+                    
+                    guard let challenge = String (data: data, encoding: .utf8) else {
+                        continue
+                    }
+                    
+                    let password = session.promptFunc! (challenge)
+                    let response = password.withCString {
+                        LIBSSH2_USERAUTH_KBDINT_RESPONSE(text: strdup($0), length: UInt32(strlen(password)))
+                    }
+                    responses?[i] = response
                 }
-                if ret == LIBSSH2_ERROR_EAGAIN {
-                    return true
-                }
-                c.resume(returning: authErrorToString(code: ret))
-                return false
             }
-            if op() {
-                tasks.append(op)
+        })
+    }
+    
+    // TODO: we should likely handle the password change callback requirement:
+    // The callback: If the host accepts authentication but requests that the password be changed,
+    // this callback will be issued. If no callback is defined, but server required password change,
+    // authentication will fail.
+    //
+    // TODO: the above is the last parameter to libssh2_userauth_password_ex
+    public func userAuthPassword (username: String, password: String) async -> String? {
+        return authErrorToString(code: await callSsh {
+            let usernameCount = UInt32(username.utf8.count)
+            let passwordCount = UInt32(password.utf8.count)
+            
+            return libssh2_userauth_password_ex (self.sessionHandle, username, usernameCount, password, passwordCount, nil)
+        })
+    }
+    
+    public func userAuthPublicKeyFromMemory (username: String, passPhrase: String, publicKey: String, privateKey: String) async -> String? {
+        let ret = await callSsh {
+            // Use the withCString rather than going to Data and then to pointers, because libssh2 ignores in some paths the size of the
+            // parameters and instead relies on a NUL characters at the end of the string to determine the size.
+            
+            let usernameCount = username.utf8.count
+            return privateKey.withCString {
+                let privPtr = $0
+                
+                return publicKey.withCString {
+                    let pubPtr = $0
+                    return libssh2_userauth_publickey_frommemory(self.sessionHandle, username, usernameCount, pubPtr, strlen(pubPtr), privPtr, strlen(privPtr), passPhrase)
+                }
             }
         }
+        return authErrorToString(code: ret)
+    }
+    
+    public func userAuthWithCallback (username: String, publicKey: Data, signCallback: @escaping (Data)->Data?) async -> String? {
+        let ret = await callSsh {
+            var rc: CInt = 0
+            let cbData = callbackData (pub: publicKey, signCallback: signCallback)
+            let ptrCbData = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(capacity: 1)
+            ptrCbData.pointee = Unmanaged.passUnretained(cbData).toOpaque()
+            
+            
+            publicKey.withUnsafeBytes {
+                let pubPtr = $0.bindMemory(to: UInt8.self).baseAddress!
+                
+                let count = publicKey.count
+                rc = libssh2_userauth_publickey (self.sessionHandle, username, pubPtr, count, authenticateCallback, ptrCbData)
+            }
+            return rc
+        }
+        return authErrorToString(code: ret)
     }
     
     public func makeKnownHost () -> LibsshKnownHost? {
@@ -177,6 +255,21 @@ actor SessionActor {
             return nil
         }
         return LibsshKnownHost (sessionActor: self, knownHost: kh)
+    }
+    
+    
+    public func getFingerprintBytes () -> [UInt8]? {
+        guard let hashPointer = libssh2_hostkey_hash(sessionHandle, LIBSSH2_HOSTKEY_HASH_SHA256) else {
+            return nil
+        }
+        
+        let hash = UnsafeRawPointer(hashPointer).assumingMemoryBound(to: UInt8.self)
+        
+        return (0..<32).map({ UInt8(hash[$0]) })
+    }
+    
+    public func getBanner () -> String {
+        return String (cString: libssh2_session_banner_get(sessionHandle))
     }
     
     public func readFile (_ khHandle: OpaquePointer, filename: String) -> String? {
@@ -187,76 +280,97 @@ actor SessionActor {
         return nil
     }
     
-    public func openChannel (type: String, windowSize: CUnsignedInt = 2*1024*1024, packetSize: CUnsignedInt = 32768, readCallback: @escaping (Channel, Data?, Data?)->()) async -> Channel? {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                var ret: OpaquePointer?
-                
-                let typeCount = UInt32(type.utf8.count)
-                ret = libssh2_channel_open_ex(self.sessionHandle, type, typeCount, windowSize, packetSize, nil, 0)
-                if ret == nil {
-                    if libssh2_session_last_errno (self.sessionHandle) == LIBSSH2_ERROR_EAGAIN {
-                        return true
-                    }
-                    c.resume(returning: nil)
-                } else {
-                    let channel = Channel (session: self, channelHandle: ret!, readCallback: readCallback)
-                    c.resume(returning: channel)
-                }
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+    public func openChannel (type: String, windowSize: CUnsignedInt = 2*1024*1024, packetSize: CUnsignedInt = 32768, readCallback: @escaping (Channel, Data?, Data?)->()) async -> OpaquePointer? {
+        
+        return await callSshPtr {
+            return libssh2_channel_open_ex(self.sessionHandle, type, UInt32(type.utf8.count), windowSize, packetSize, nil, 0)
         }
     }
     
-    public func channelSetEnv (_ channelHandle: OpaquePointer, name: String, value: String) async -> Int32 {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                let ret = libssh2_channel_setenv_ex (channelHandle, name, UInt32(name.utf8.count), value, UInt32(value.utf8.count))
-                if ret == LIBSSH2_ERROR_EAGAIN {
-                    return true
-                }
-                c.resume(returning: ret)
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+    public func channelSetEnv (_ channel: Channel, name: String, value: String) async -> Int32 {
+        return await callSsh {
+            libssh2_channel_setenv_ex (channel.channelHandle, name, UInt32(name.utf8.count), value, UInt32(value.utf8.count))
         }
     }
     
-    public func requestPseudoTerminal (_ channelHandle: OpaquePointer, name: String, cols: Int, rows: Int) async -> Int32 {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                let ret = libssh2_channel_request_pty_ex(channelHandle, name, UInt32(name.utf8.count), nil, 0, Int32(cols), Int32(rows), LIBSSH2_TERM_WIDTH_PX, LIBSSH2_TERM_HEIGHT_PX)
-                if ret == LIBSSH2_ERROR_EAGAIN {
-                    return true
-                }
-                c.resume(returning: ret)
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+    public func requestPseudoTerminal (_ channel: Channel, name: String, cols: Int, rows: Int) async -> Int32 {
+        return await callSsh {
+            libssh2_channel_request_pty_ex(channel.channelHandle, name, UInt32(name.utf8.count), nil, 0, Int32(cols), Int32(rows), LIBSSH2_TERM_WIDTH_PX, LIBSSH2_TERM_HEIGHT_PX)
         }
     }
     
-    public func processStartup (_ channelHandle: OpaquePointer, request: String, message: String?) async -> Int32 {
-        return await withUnsafeContinuation { c in
-            let op: queuedOp = {
-                let ret = libssh2_channel_process_startup (channelHandle, request, UInt32(request.utf8.count), message, message == nil ? 0 : UInt32(message!.utf8.count))
-                if ret == LIBSSH2_ERROR_EAGAIN {
-                    return true
-                }
-                c.resume(returning: ret)
-                return false
-            }
-            if op() {
-                tasks.append(op)
-            }
+    public func processStartup (_ channel: Channel, request: String, message: String?) async -> Int32 {
+        return await callSsh {
+            libssh2_channel_process_startup (channel.channelHandle, request, UInt32(request.utf8.count), message, message == nil ? 0 : UInt32(message!.utf8.count))
         }
+    }
+    
+    public func setTerminalSize (_ channel: Channel, cols: Int, rows: Int, pixelWidth: Int, pixelHeight: Int) async {
+        let _ = await callSsh {
+            libssh2_channel_request_pty_size_ex(channel.channelHandle, Int32(cols), Int32(rows), Int32(pixelWidth), Int32(pixelHeight))
+        }
+    }
+    
+    public func openSftp () async -> OpaquePointer? {
+        return await callSshPtr { libssh2_sftp_init(self.sessionHandle) }
+    }
+    
+    public func disconnect (reason: Int32 = SSH_DISCONNECT_BY_APPLICATION, description: String) async {
+        let _ = await callSsh {
+            libssh2_session_disconnect_ex(self.sessionHandle, reason, description, "")
+        }
+    }
+
+    // SFTP APIs
+    func sftpStat (_ sftp: SFTP, path: String) async -> LIBSSH2_SFTP_ATTRIBUTES? {
+        var attr: LIBSSH2_SFTP_ATTRIBUTES = LIBSSH2_SFTP_ATTRIBUTES()
+        let pc = UInt32 (path.utf8.count)
+        
+        let ret = await callSsh {
+            libssh2_sftp_stat_ex(sftp.sftpHandle, path, pc, LIBSSH2_SFTP_STAT, &attr)
+        }
+        return ret == 0 ? attr : nil
+    }
+    
+    func sftpLlOpen (_ sftp: SFTP, path: String, flags: UInt, file: Bool) async -> OpaquePointer? {
+        return await callSshPtr {
+            libssh2_sftp_open_ex(sftp.sftpHandle, path, UInt32 (path.utf8.count), flags, 0, file ? LIBSSH2_SFTP_OPENFILE : LIBSSH2_SFTP_OPENDIR)
+        }
+    }
+    
+    public func sftpShutdown (_ sftpHandle: OpaquePointer) async {
+        libssh2_sftp_shutdown (sftpHandle)
+    }
+        
+    func sftpReadFile (_ sftp: SFTP, path: String, limit: Int) async -> [Int8]? {
+        guard let f = await sftpLlOpen (sftp, path: path, flags: UInt (LIBSSH2_FXF_READ), file: true) else {
+            return nil
+        }
+        var buffer: [Int8] = []
+        let size = 8192
+        var llbuffer = Array<Int8>.init(repeating: 0, count: size)
+        var ret: Int = 0
+        var left = limit
+        let _ = await callSsh {
+            repeat {
+                ret = libssh2_sftp_read(f, &llbuffer, min (size, left))
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return Int32 (ret)
+                }
+                if ret > 0 {
+                    left -= ret
+                    buffer.append(contentsOf: llbuffer [0..<ret])
+                }
+                if ret == 0 {
+                    return Int32 (ret)
+                }
+            } while left > 0
+            return 0
+        }
+        let _ = await callSsh {
+            libssh2_sftp_close_handle(f)
+        }
+        return buffer
     }
 }
     

--- a/SwiftTermApp/Ssh/SessionActor.swift
+++ b/SwiftTermApp/Ssh/SessionActor.swift
@@ -1,0 +1,286 @@
+//
+// TODO:
+//  - Handle disconnect
+//  - Do I still care about timeout as a global?   With this async framework, perhaps the timeout needs to be implemented elsewhere
+//
+//  SessionActor.swift
+//  SwiftTermApp
+//
+//  Created by Miguel de Icaza on 2/3/22.
+//  Copyright © 2022 Miguel de Icaza. All rights reserved.
+//
+import Foundation
+import CSwiftSH
+import Network
+import CryptoKit
+
+@_implementationOnly import CSSH
+
+typealias socketCbType = @convention(c) (libssh2_socket_t, UnsafeRawPointer, size_t, CInt, UnsafeRawPointer) -> ssize_t
+typealias debugCbType  = @convention(c) (libssh2_socket_t, CInt, UnsafeRawPointer, CInt, UnsafeRawPointer, CInt, UnsafeRawPointer) -> ()
+typealias disconnectCbType = @convention(c) (UnsafeRawPointer, CInt,
+                                           UnsafePointer<CChar>, CInt,
+                                           UnsafePointer<CChar>, CInt, UnsafeRawPointer) -> Void
+
+typealias queuedOp = ()->Bool
+
+actor SessionActor {
+    // Handle to the libssh2 Session
+    var sessionHandle: OpaquePointer!
+
+    init (fakeSetup: Bool) { }
+    init (send: @escaping socketCbType, recv: @escaping socketCbType, debug: @escaping debugCbType, opaque: UnsafeMutableRawPointer) {
+        libssh2_init (0)
+        sessionHandle = libssh2_session_init_ex(nil, nil, nil, opaque)
+        let flags: Int32 = 0
+        libssh2_trace(sessionHandle, flags)
+        libssh2_trace_sethandler(sessionHandle, nil, { session, context, data, length in
+            var str: String
+            if let ptr = data {
+                str = String (cString: ptr)
+            } else {
+                str = "<null>"
+            }
+            print ("Trace callback: \(str)")
+        })
+        
+        // TODO
+//        let callback: disconnectType = { sessionPtr, reason, message, messageLen, language, languageLen, abstract in
+//            let session = Session.getSession(from: abstract)
+//
+//            print ("On session: \(session)")
+//            print ("Disconnected")
+//            session.disconnect(reason: SSH_DISCONNECT_CONNECTION_LOST, description: "")
+//        }
+        //libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DISCONNECT, unsafeBitCast(callback, to: UnsafeMutableRawPointer.self))
+        
+        libssh2_session_set_blocking (sessionHandle, 0)
+        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_SEND, unsafeBitCast(send, to: UnsafeMutableRawPointer.self))
+        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_RECV, unsafeBitCast(recv, to: UnsafeMutableRawPointer.self))
+        libssh2_session_callback_set(sessionHandle, LIBSSH2_CALLBACK_DEBUG, unsafeBitCast(debug, to: UnsafeMutableRawPointer.self))
+    }
+
+    // These tasks return true if they should be kept on the list
+    var tasks: [()->Bool] = []
+    
+    public func pingTasks () {
+        var copy = tasks
+        tasks = []
+        
+        for task in copy {
+            if task() {
+                tasks.append(task)
+            }
+        }
+    }
+    
+    public func hostKey () -> (key: [Int8], type: Int32)? {
+        var len: Int = 0
+        var type: Int32 = 0
+
+        let ptr = libssh2_session_hostkey(sessionHandle, &len, &type)
+        if ptr == nil {
+            return nil
+        }
+        let data = UnsafeBufferPointer (start: ptr, count: len)
+        return (data.map { $0 }, type)
+    }
+
+    public func handshake () async -> Int32 {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = libssh2_session_handshake(self.sessionHandle, 0)
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+
+    public var timeout: Date?
+    
+    public func userAuthenticationList (username: String) async -> [String] {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                var result: UnsafeMutablePointer<CChar>!
+                
+                self.timeout = Date (timeIntervalSinceNow: 2)
+                result = libssh2_userauth_list (self.sessionHandle, username, UInt32(username.utf8.count))
+                self.timeout = nil
+                if result == nil {
+                    let code = libssh2_session_last_errno(self.sessionHandle)
+                    if code == LIBSSH2_ERROR_EAGAIN {
+                        return true
+                    }
+                    c.resume(returning: [])
+                } else {
+                    c.resume (returning: String (validatingUTF8: result)?.components(separatedBy: ",") ?? [])
+                }
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+        
+    public var authenticated: Bool {
+        get {
+            return libssh2_userauth_authenticated(sessionHandle) == 1
+        }
+    }
+    
+    public func userAuthKeyboardInteractive (username: String) async -> String? {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let usernameCount = UInt32 (username.utf8.count)
+                let ret = libssh2_userauth_keyboard_interactive_ex(self.sessionHandle, username, usernameCount) { name, nameLen, instruction, instructionLen, numPrompts, prompts, responses, abstract in
+                    let session = Session.getSession(from: abstract!)
+
+                    for i in 0..<Int(numPrompts) {
+                        guard let promptI = prompts?[i], let text = promptI.text else {
+                            continue
+                        }
+                        
+                        let data = Data (bytes: UnsafeRawPointer (text), count: Int(promptI.length))
+                        
+                        guard let challenge = String (data: data, encoding: .utf8) else {
+                            continue
+                        }
+                        
+                        let password = session.promptFunc! (challenge)
+                        let response = password.withCString {
+                            LIBSSH2_USERAUTH_KBDINT_RESPONSE(text: strdup($0), length: UInt32(strlen(password)))
+                        }
+                        responses?[i] = response
+                    }
+                }
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: authErrorToString(code: ret))
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+    
+    public func makeKnownHost () -> LibsshKnownHost? {
+        guard let kh = libssh2_knownhost_init (sessionHandle) else {
+            return nil
+        }
+        return LibsshKnownHost (sessionActor: self, knownHost: kh)
+    }
+    
+    public func readFile (_ khHandle: OpaquePointer, filename: String) -> String? {
+        let ret = libssh2_knownhost_readfile(khHandle, filename, LIBSSH2_KNOWNHOST_FILE_OPENSSH)
+        if ret < 0 {
+            return libSsh2ErrorToString(error: ret)
+        }
+        return nil
+    }
+    
+    public func openChannel (type: String, windowSize: CUnsignedInt = 2*1024*1024, packetSize: CUnsignedInt = 32768, readCallback: @escaping (Channel, Data?, Data?)->()) async -> Channel? {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                var ret: OpaquePointer?
+                
+                let typeCount = UInt32(type.utf8.count)
+                ret = libssh2_channel_open_ex(self.sessionHandle, type, typeCount, windowSize, packetSize, nil, 0)
+                if ret == nil {
+                    if libssh2_session_last_errno (self.sessionHandle) == LIBSSH2_ERROR_EAGAIN {
+                        return true
+                    }
+                    c.resume(returning: nil)
+                } else {
+                    let channel = Channel (session: self, channelHandle: ret!, readCallback: readCallback)
+                    c.resume(returning: channel)
+                }
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+    
+    public func channelSetEnv (_ channelHandle: OpaquePointer, name: String, value: String) async -> Int32 {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = libssh2_channel_setenv_ex (channelHandle, name, UInt32(name.utf8.count), value, UInt32(value.utf8.count))
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+    
+    public func requestPseudoTerminal (_ channelHandle: OpaquePointer, name: String, cols: Int, rows: Int) async -> Int32 {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = libssh2_channel_request_pty_ex(channelHandle, name, UInt32(name.utf8.count), nil, 0, Int32(cols), Int32(rows), LIBSSH2_TERM_WIDTH_PX, LIBSSH2_TERM_HEIGHT_PX)
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+    
+    public func processStartup (_ channelHandle: OpaquePointer, request: String, message: String?) async -> Int32 {
+        return await withUnsafeContinuation { c in
+            let op: queuedOp = {
+                let ret = libssh2_channel_process_startup (channelHandle, request, UInt32(request.utf8.count), message, message == nil ? 0 : UInt32(message!.utf8.count))
+                if ret == LIBSSH2_ERROR_EAGAIN {
+                    return true
+                }
+                c.resume(returning: ret)
+                return false
+            }
+            if op() {
+                tasks.append(op)
+            }
+        }
+    }
+}
+    
+// Returns nil on success, or a description of the code on error
+public func authErrorToString (code: CInt) -> String? {
+    switch code {
+    case 0:
+        // We are fine, return
+        return nil
+    case LIBSSH2_ERROR_ALLOC:
+        // WE are doomed, return
+        return "Memory allocation failure"
+    case LIBSSH2_ERROR_SOCKET_SEND:
+        // We are doomed return, upper Network layer will notify of this problem
+        return "Unable to send data to remote host"
+    case LIBSSH2_ERROR_PASSWORD_EXPIRED:
+        // the password expired, but we failed to change it (to fix, we will need to provide a callback)
+        return "Password expired"
+    case LIBSSH2_ERROR_AUTHENTICATION_FAILED:
+        // Failed, try the next password
+        return "Password authentication failed"
+    default:
+        // Unknown error, return
+        return "Unknown error during authentication"
+    }
+}
+


### PR DESCRIPTION
Move to use actors and async/await instead of manually managing state with queues, and avoiding busy loops.

First, this set of changes uses both actors to simplify the requirements to only call libssh2 methods on a session from the same thread.  Previously this was enforced by sending all operations to an sshQueue, now all code that needs to be bound to a single thread are instead pushed to an actor, in this case SessionActor.   In libssh2, multi-threading can happen only for different sessions, and any objects that rely on it.

The new SessionActor has thus all the operations on an libssh session, the channels (that are tied to it), and SFTP (tied to it as well).

Second, previously, when libssh2 was unable to complete a request, it would return EAGAIN, and my code would busy loop until enough data was received or sent.   This is problematic, as this would just spin the code waiting for a potentially slow network connection.   Not only was this burning GPU, in addition, it would hoard the sshQueue, so if a libssh2 call had to be retried, no further operations could be processed until this was done.   While this was acceptable for most uses of a terminal emulator, it would prevent me from reusing libssh for transferring files and not clog the system.

Actors had the nice side effect of dealing with problems that I previously had to debug with assertions on specific queues, and during the development, I did not experience deadlocks (which were way too common to introduce with my manual queue management) or memory corruption issues.   