### PR TITLE
Register ssh:// and swiftterm:// as schemes the application can handle

### DIFF
--- a/SwiftTermApp.xcodeproj/project.pbxproj
+++ b/SwiftTermApp.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		49F1D13927DA5F11004A9CB1 /* swcrypt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 49F1D13527DA5F11004A9CB1 /* swcrypt.txt */; };
 		49F1D14127DAB782004A9CB1 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F1D14027DAB782004A9CB1 /* UITests.swift */; };
 		49F1D14327DAB782004A9CB1 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F1D14227DAB782004A9CB1 /* UITestsLaunchTests.swift */; };
+		49F1D14A27DD0FFF004A9CB1 /* SideHostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F1D14927DD0FFF004A9CB1 /* SideHostStatus.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -170,6 +171,7 @@
 		49F1D13E27DAB782004A9CB1 /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		49F1D14027DAB782004A9CB1 /* UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
 		49F1D14227DAB782004A9CB1 /* UITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestsLaunchTests.swift; sourceTree = "<group>"; };
+		49F1D14927DD0FFF004A9CB1 /* SideHostStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideHostStatus.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -325,6 +327,7 @@
 				49A0A2BD2491C792002593F7 /* LazyView.swift */,
 				49A0A2BF2491CDC4002593F7 /* InteractiveLogin.swift */,
 				49BA35A526784B6B00B63510 /* Passphrase.swift */,
+				49F1D14927DD0FFF004A9CB1 /* SideHostStatus.swift */,
 			);
 			path = UIs;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				4923C56627319336000CC371 /* LocationTracking.swift in Sources */,
 				49011690245607F7002C1F85 /* Hosts.swift in Sources */,
 				4911B3042463AD3E00816BAA /* GenerateKey.swift in Sources */,
+				49F1D14A27DD0FFF004A9CB1 /* SideHostStatus.swift in Sources */,
 				49F0741024834B9D00A83CDC /* AppTerminalView.swift in Sources */,
 				49F0740C2481B3ED00A83CDC /* ColorLoader.swift in Sources */,
 				4901167A24553789002C1F85 /* Home.swift in Sources */,

--- a/SwiftTermApp/AppDelegate.swift
+++ b/SwiftTermApp/AppDelegate.swift
@@ -10,6 +10,7 @@ import SwiftUI
 @main
 struct SampleApp: App {
     @State var dates = [Date]()
+    @State var launchHost: Host?
     
     init () {
         if settings.locationTrack {

--- a/SwiftTermApp/Info.plist
+++ b/SwiftTermApp/Info.plist
@@ -41,6 +41,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.tirania.SwiftTermAppX</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>swiftterm</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/SwiftTermApp/Info.plist
+++ b/SwiftTermApp/Info.plist
@@ -53,6 +53,16 @@
 				<string>swiftterm</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>org.tirania.SwiftTermAppX</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ssh</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>

--- a/SwiftTermApp/Ssh/Session.swift
+++ b/SwiftTermApp/Ssh/Session.swift
@@ -141,7 +141,7 @@ class Session: CustomDebugStringConvertible {
             // There was an error
             // TODO: handle this one
         }
-        banner = await sessionActor.getBanner () 
+        banner = await sessionActor.getBanner ()
         let failureReason = await delegate.authenticate(session: self)
         if await authenticated {
             await delegate.loggedIn(session: self)

--- a/SwiftTermApp/UIs/SideHostStatus.swift
+++ b/SwiftTermApp/UIs/SideHostStatus.swift
@@ -1,0 +1,21 @@
+//
+//  SideHostStatus.swift
+//  SwiftTermApp
+//
+//  Created by Miguel de Icaza on 3/12/22.
+//  Copyright © 2022 Miguel de Icaza. All rights reserved.
+//
+
+import SwiftUI
+
+struct SideHostStatus: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct SideHostStatus_Previews: PreviewProvider {
+    static var previews: some View {
+        SideHostStatus()
+    }
+}


### PR DESCRIPTION
This allows openURL on urls like "ssh://root@192.168.1.2" to be used.